### PR TITLE
Fix memory issues

### DIFF
--- a/apps/siri-sx-demo-client/embed.html
+++ b/apps/siri-sx-demo-client/embed.html
@@ -81,7 +81,7 @@
                 <hr/>
 
                 <div class="mb-3">
-                    <div>Last Update: <mark>12.Dec 2024</mark> • Source Code: <a href="https://github.com/openTdataCH/siri-sx-situation-monitor" target="_blank">openTdataCH / siri-sx-situation-monitor</a> • Documentation: <a href="https://github.com/openTdataCH/siri-sx-situation-monitor/blob/main/docs/embed_siri.md" target="_blank">./docs/embed_siri.md</a></div>
+                    <div>Last Update: <mark>4.Apr 2025</mark> • Source Code: <a href="https://github.com/openTdataCH/siri-sx-situation-monitor" target="_blank">openTdataCH / siri-sx-situation-monitor</a> • Documentation: <a href="https://github.com/openTdataCH/siri-sx-situation-monitor/blob/main/docs/embed_siri.md" target="_blank">./docs/embed_siri.md</a></div>
                     <div>Response Source: <span id="response_source"></span></div>
                     <div class="d-flex gap-2">
                         <div>Stats: </div>

--- a/apps/siri-sx-demo-client/embed.html
+++ b/apps/siri-sx-demo-client/embed.html
@@ -9,7 +9,7 @@
 
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.0/font/bootstrap-icons.css" />
         
-        <link href="assets/css/page.css?v=18" rel="stylesheet" />
+        <link href="assets/css/page.css?v=21" rel="stylesheet" />
     </head>
 
     <body class="bg-light">
@@ -215,6 +215,6 @@
                 'page_type': 'embed'
             };
         </script>
-        <script src="assets/js-dist/bundle.js?v=18" charset="utf-8"></script>
+        <script src="assets/js-dist/bundle.js?v=21" charset="utf-8"></script>
     </body>
 </html>

--- a/apps/siri-sx-demo-client/ts/controllers/messages_embed_controller.ts
+++ b/apps/siri-sx-demo-client/ts/controllers/messages_embed_controller.ts
@@ -683,7 +683,7 @@ export default class Messages_Embed_Controller {
         serviceQueryParams['service_day'] = serviceDay;
         
         const qs = new URLSearchParams(serviceQueryParams);
-        const gtfsTripsURL = 'https://tools.odpch.ch/gtfs-rt-status/api/gtfs-query/trips?' + qs;
+        const gtfsTripsURL = 'https://tools.odpch.ch/gtfs-query/trips?' + qs;
 
         const gtfsTripsJSON = await (await fetch(gtfsTripsURL)).json() as GTFS_DB_Trips_Response;
 

--- a/apps/siri-sx-demo-client/ts/controllers/messages_embed_controller.ts
+++ b/apps/siri-sx-demo-client/ts/controllers/messages_embed_controller.ts
@@ -1,6 +1,7 @@
 import { App_Stage } from "../config/app_config";
 import { DateHelpers } from "../helpers/date-helpers";
 import { DOM_Helpers } from "../helpers/DOM_Helpers";
+import { SIRI_SX_Helpers } from "../helpers/siri-sx-helpers";
 import { GTFS_DB_Trips_Response, GTFS_Trip } from "../models/gtfs_db";
 import { AffectedLineNetworkWithStops, AffectedVehicleJourney, LangEnum, LineNetwork, PublishingAction, PublishingActionAffect, ScopeType, StopPlace, TextualContentSizeEnum, TimeInterval } from "../models/pt_all.interface";
 import PtSituationElement from "../models/pt_situation_element";
@@ -256,7 +257,7 @@ export default class Messages_Embed_Controller {
             }
 
             const matchedActions = situationElement.publishingActions.filter(action => {
-                const hasOwnerRef = this._match_text(situationElement.situationNumber, action.passengerInformation.ownerRef);
+                const hasOwnerRef = SIRI_SX_Helpers.matchText(this.filter_texts, situationElement.situationNumber, action.passengerInformation.ownerRef);
                 if (!hasOwnerRef) {
                     return false;
                 }
@@ -288,33 +289,6 @@ export default class Messages_Embed_Controller {
         });
 
         return matchedActionsData;
-    }
-
-    private _match_text(situationNumber: string, ownerRef: string | null): boolean {
-        if (this.filter_texts === null) {
-            return true;
-        }
-
-        if (this.filter_texts.includes(situationNumber)) {
-            return true;
-        }
-
-        if (ownerRef === null) {
-            return false;
-        }
-
-        const sanitizeOwnerRef = (s: string): string => {
-            return s.trim().toLowerCase().replace('ch:1:sboid:', '');
-        };
-
-        ownerRef = sanitizeOwnerRef(ownerRef);
-
-        const foundOwnerRef = this.filter_texts.find(filter_text => {
-            filter_text = sanitizeOwnerRef(filter_text);
-            return ownerRef === filter_text;
-        }) ?? null;
-
-        return foundOwnerRef !== null;
     }
 
     private _compute_situation_element_card_HTML(matchedActionData: MatchedAction, rowIDX: number, totalRowsNo: number): string {

--- a/apps/siri-sx-demo-client/ts/controllers/messages_fetch_controller.ts
+++ b/apps/siri-sx-demo-client/ts/controllers/messages_fetch_controller.ts
@@ -62,26 +62,19 @@ export default class Messages_Fetch_Controller {
         response.text().then(responseXMLText => {
             console.log('STATS response: DONE PARSE text()');
 
+            const situationElementMatches: string[] = responseXMLText.match(/<PtSituationElement\b[^>]*>.*?<\/PtSituationElement>/gs) ?? [];
+            console.log('STATS response: found ' + situationElementMatches.length + ' PtSituationElement nodes');
+            this.map_elements['stats_situation_nodes_no'].innerHTML = '' + situationElementMatches.length;
+
             const situationElements: PtSituationElement[] = [];
+            situationElementMatches.forEach(situationElementMatch => {
+                const dom = new DOMParser().parseFromString(situationElementMatch, 'application/xml');
+                const node = XPathHelpers.queryNode('/PtSituationElement', dom);
+                if (node === null) {
+                    return;
+                }
 
-            const responseDocument = new DOMParser().parseFromString(responseXMLText, 'application/xml');
-            console.log('STATS response: DONE DOMParser().parseFromString');
-
-            const situationsRootNode = XPathHelpers.queryNode('//siri:SituationExchangeDelivery', responseDocument);
-            if (situationsRootNode === null) {
-                const errorMessage = 'Failed to parse, check console for the responseText';
-                console.error('ERROR - responseText:');
-                console.log(responseXMLText);
-                completion([], errorMessage);
-                return;
-            }
-
-            const situationNodes = XPathHelpers.queryNodes('siri:Situations/siri:PtSituationElement', situationsRootNode);
-            console.log('STATS response: found ' + situationNodes.length + ' PtSituationElement nodes');
-            this.map_elements['stats_situation_nodes_no'].innerHTML = '' + situationNodes.length;
-
-            situationNodes.forEach(situationNode => {
-                const situationElement = PtSituationElement.initFromSituationNode(situationNode);
+                const situationElement = PtSituationElement.initFromSituationNode(node);
                 if (situationElement) {
                     situationElements.push(situationElement);
                 }

--- a/apps/siri-sx-demo-client/ts/helpers/siri-sx-helpers.ts
+++ b/apps/siri-sx-demo-client/ts/helpers/siri-sx-helpers.ts
@@ -1,0 +1,28 @@
+export class SIRI_SX_Helpers {
+  public static matchText(filterTexts: string[] | null, situationNumber: string, ownerRef: string | null): boolean {
+    if (filterTexts === null) {
+      return true;
+    }
+
+    if (filterTexts.includes(situationNumber)) {
+      return true;
+    }
+
+    if (ownerRef === null) {
+      return false;
+    }
+
+    const sanitizeOwnerRef = (s: string): string => {
+      return s.trim().toLowerCase().replace('ch:1:sboid:', '');
+    };
+
+    ownerRef = sanitizeOwnerRef(ownerRef);
+
+    const foundOwnerRef = filterTexts.find(filter_text => {
+      filter_text = sanitizeOwnerRef(filter_text);
+      return ownerRef === filter_text;
+    }) ?? null;
+
+    return foundOwnerRef !== null;
+  }
+}

--- a/apps/siri-sx-demo-client/ts/helpers/xpath.ts
+++ b/apps/siri-sx-demo-client/ts/helpers/xpath.ts
@@ -1,7 +1,7 @@
 import xpath from 'xpath'
 
 const mapNS = {
-  'siri' : 'http://www.siri.org.uk/siri',
+  // 'siri' : 'http://www.siri.org.uk/siri',
 };
 
 export class XPathHelpers {

--- a/apps/siri-sx-demo-client/ts/models/pt_situation_element.ts
+++ b/apps/siri-sx-demo-client/ts/models/pt_situation_element.ts
@@ -354,7 +354,23 @@ export default class PtSituationElement {
     private static computeAffectedJourneys(situationNumber: string, publishingActionNode: Node): AffectedVehicleJourney[] {
         const affectedVehicleJourneys: AffectedVehicleJourney[] = [];
 
-        const affectedVehicleJourneyNodes = XPathHelpers.queryNodes('siri:PublishAtScope/siri:Affects/siri:VehicleJourneys/siri:AffectedVehicleJourney', publishingActionNode);
+        const affectedVehicleJourneyNodes: Node[] = (() => {
+            const maxTagsCount = 100;
+
+            const publishingActionNodeS = new XMLSerializer().serializeToString(publishingActionNode);
+            const tagName = "AffectedVehicleJourney";
+            const regex = new RegExp(`<${tagName}[^>]*>(.*?)</${tagName}>`, "gs");
+            const tagsCount = (publishingActionNodeS.match(regex) || []).length;
+
+            if (tagsCount < maxTagsCount) {
+                const nodes = XPathHelpers.queryNodes('PublishAtScope/Affects/VehicleJourneys/AffectedVehicleJourney', publishingActionNode);
+                return nodes;
+            }
+
+            console.error('ERROR - too many ' + tagsCount + ' <AffectedVehicleJourney> nodes for ' + situationNumber);
+            return [];
+        })();
+
         affectedVehicleJourneyNodes.forEach((vehicleJourneyNode, idx) => {
             const framedVehicleJourneyRefNode = XPathHelpers.queryNode('FramedVehicleJourneyRef', vehicleJourneyNode);
             if (framedVehicleJourneyRefNode === null) {

--- a/apps/siri-sx-demo-client/ts/models/pt_situation_element.ts
+++ b/apps/siri-sx-demo-client/ts/models/pt_situation_element.ts
@@ -50,9 +50,9 @@ export default class PtSituationElement {
     }
 
     public static initFromSituationNode(node: Node): PtSituationElement | null {
-        const situationNumber = XPathHelpers.queryText('siri:SituationNumber', node);
+        const situationNumber = XPathHelpers.queryText('SituationNumber', node);
         
-        const creationTimeS = XPathHelpers.queryText('siri:CreationTime', node);
+        const creationTimeS = XPathHelpers.queryText('CreationTime', node);
         if (creationTimeS === null) {
             Logger.logMessage('ERROR - creationTimeS is null', 'PtSituationElement.initFromSituationNode');
             Logger.log(node);
@@ -60,10 +60,10 @@ export default class PtSituationElement {
         }
         const creationTime = new Date(creationTimeS);
         
-        const countryRef = XPathHelpers.queryText('siri:CountryRef', node);
-        const participantRef = XPathHelpers.queryText('siri:ParticipantRef', node);
+        const countryRef = XPathHelpers.queryText('CountryRef', node);
+        const participantRef = XPathHelpers.queryText('ParticipantRef', node);
         
-        const versionS = XPathHelpers.queryText('siri:Version', node);
+        const versionS = XPathHelpers.queryText('Version', node);
         if (versionS === null) {
             Logger.logMessage('ERROR - Version is NULL', 'PtSituationElement.initFromSituationNode');
             Logger.log(node);
@@ -73,13 +73,13 @@ export default class PtSituationElement {
 
         const situationSource = PtSituationSource.initFromSituationNode(node);
 
-        const situationProgress = XPathHelpers.queryText('siri:Progress', node);
+        const situationProgress = XPathHelpers.queryText('Progress', node);
 
         const validityPeriods: TimeInterval[] = [];
-        const validityPeriodNodes = XPathHelpers.queryNodes('siri:ValidityPeriod', node);
+        const validityPeriodNodes = XPathHelpers.queryNodes('ValidityPeriod', node);
         validityPeriodNodes.forEach(validityPeriodNode => {
-            const validityPeriodStartDateS = XPathHelpers.queryText('siri:StartTime', validityPeriodNode);
-            const validityPeriodEndDateS = XPathHelpers.queryText('siri:EndTime', validityPeriodNode);
+            const validityPeriodStartDateS = XPathHelpers.queryText('StartTime', validityPeriodNode);
+            const validityPeriodEndDateS = XPathHelpers.queryText('EndTime', validityPeriodNode);
             if (!(validityPeriodStartDateS && validityPeriodEndDateS)) {
                 return;
             }
@@ -97,9 +97,9 @@ export default class PtSituationElement {
             return null;            
         }
 
-        const alertCause = XPathHelpers.queryText('siri:AlertCause', node);
+        const alertCause = XPathHelpers.queryText('AlertCause', node);
         
-        const situationPriorityS = XPathHelpers.queryText('siri:Priority', node);
+        const situationPriorityS = XPathHelpers.queryText('Priority', node);
         if (situationPriorityS === null) {
             Logger.logMessage('ERROR - Priority is NULL', 'PtSituationElement.initFromSituationNode');
             Logger.log(node);
@@ -113,7 +113,7 @@ export default class PtSituationElement {
             return null;
         }
 
-        const plannedS = XPathHelpers.queryText('siri:Planned', node);
+        const plannedS = XPathHelpers.queryText('Planned', node);
         const isPlanned = plannedS === 'true';
 
         const publishingActions = PtSituationElement.computePublishingActionsFromSituationNode(situationNumber, node);
@@ -129,7 +129,7 @@ export default class PtSituationElement {
     private static computePublishingActionsFromSituationNode(situationNumber: string, node: Node): PublishingAction[] {
         const publishingActions: PublishingAction[] = [];
 
-        const publishingActionNodes = XPathHelpers.queryNodes('siri:PublishingActions/siri:PublishingAction', node);
+        const publishingActionNodes = XPathHelpers.queryNodes('PublishingActions/PublishingAction', node);
         publishingActionNodes.forEach(publishingActionNode => {
             const publishingAction = PtSituationElement.computePublishingAction(situationNumber, publishingActionNode);
             if (publishingAction === null) {
@@ -145,7 +145,7 @@ export default class PtSituationElement {
     }
 
     private static computePublishingAction(situationNumber: string, publishingActionNode: Node): PublishingAction | null {
-        const infoActionNode = XPathHelpers.queryNode('siri:PassengerInformationAction', publishingActionNode);
+        const infoActionNode = XPathHelpers.queryNode('PassengerInformationAction', publishingActionNode);
         if (infoActionNode === null) {
             console.error('computePublishingAction: NO <PassengerInformationAction>');
             console.log(situationNumber);
@@ -153,7 +153,7 @@ export default class PtSituationElement {
             return null;
         }
 
-        const actionRef = XPathHelpers.queryText('siri:ActionRef', infoActionNode)
+        const actionRef = XPathHelpers.queryText('ActionRef', infoActionNode)
         if (actionRef === null) {
             console.error('computePublishingAction: NULL actionRef');
             console.log(situationNumber);
@@ -161,9 +161,9 @@ export default class PtSituationElement {
             return null;
         }
 
-        const ownerRef = XPathHelpers.queryText('siri:OwnerRef', infoActionNode);
+        const ownerRef = XPathHelpers.queryText('OwnerRef', infoActionNode);
 
-        const scopeType = XPathHelpers.queryText('siri:PublishAtScope/siri:ScopeType', publishingActionNode) as ScopeType;
+        const scopeType = XPathHelpers.queryText('PublishAtScope/ScopeType', publishingActionNode) as ScopeType;
         if (scopeType === null) {
             console.error('computePublishingAction: NULL scopeType');
             console.log(situationNumber);
@@ -172,7 +172,7 @@ export default class PtSituationElement {
         }
 
         const perspectives: string[] = [];
-        const perspectiveNodes = XPathHelpers.queryNodes('siri:Perspective', infoActionNode)
+        const perspectiveNodes = XPathHelpers.queryNodes('Perspective', infoActionNode)
         perspectiveNodes.forEach(perspectiveNode => {
             const perspectiveText = perspectiveNode.textContent;
             if (perspectiveText) {
@@ -181,10 +181,10 @@ export default class PtSituationElement {
         });
 
         const mapTextualContent: MapTextualContent = {} as MapTextualContent;
-        const textualContentNodes = XPathHelpers.queryNodes('siri:TextualContent', infoActionNode)
+        const textualContentNodes = XPathHelpers.queryNodes('TextualContent', infoActionNode)
         textualContentNodes.forEach(textualContentNode => {
             const sizeKey: TextualContentSizeEnum | null = (() => {
-                const sizeS = XPathHelpers.queryText('siri:TextualContentSize', textualContentNode);
+                const sizeS = XPathHelpers.queryText('TextualContentSize', textualContentNode);
                 if (sizeS === 'S') {
                     return 'small'
                 }
@@ -230,9 +230,9 @@ export default class PtSituationElement {
     }
 
     private static computeAffects(situationNumber: string, scopeType: ScopeType, publishingActionNode: Node): PublishingActionAffect[] {
-        const actionAffects: PublishingActionAffect[] = []
+        const actionAffects: PublishingActionAffect[] = [];
 
-        const affectedLineNetworkNodes = XPathHelpers.queryNodes('siri:PublishAtScope/siri:Affects/siri:Networks/siri:AffectedNetwork/siri:AffectedLine', publishingActionNode);
+        const affectedLineNetworkNodes = XPathHelpers.queryNodes('PublishAtScope/Affects/Networks/AffectedNetwork/AffectedLine', publishingActionNode);
         affectedLineNetworkNodes.forEach(affectedLineNetworkNode => {
             const lineNetwork = PtSituationElement.computeLineNetwork(affectedLineNetworkNode);
             if (lineNetwork === null) {
@@ -247,9 +247,9 @@ export default class PtSituationElement {
             }
 
             if (scopeType === 'stopPlace') {
-                const directionRef = XPathHelpers.queryText('siri:Direction/siri:DirectionRef', affectedLineNetworkNode) ?? 'n/a';
+                const directionRef = XPathHelpers.queryText('Direction/DirectionRef', affectedLineNetworkNode) ?? 'n/a';
 
-                const stopPlacesNodes = XPathHelpers.queryNodes('siri:StopPlaces/siri:AffectedStopPlace', affectedLineNetworkNode);
+                const stopPlacesNodes = XPathHelpers.queryNodes('StopPlaces/AffectedStopPlace', affectedLineNetworkNode);
                 const stopPlaces = PtSituationElement.computeAffectedStopPlaces(stopPlacesNodes);
 
                 const affectedPartialLine: AffectedLineNetworkWithStops = {
@@ -266,7 +266,7 @@ export default class PtSituationElement {
         });
 
         if (scopeType === 'stopPlace') {
-            const stopPlacesNodes = XPathHelpers.queryNodes('siri:PublishAtScope/siri:Affects/siri:StopPlaces/siri:AffectedStopPlace', publishingActionNode);
+            const stopPlacesNodes = XPathHelpers.queryNodes('PublishAtScope/Affects/StopPlaces/AffectedStopPlace', publishingActionNode);
             const stopPlaces = PtSituationElement.computeAffectedStopPlaces(stopPlacesNodes)
             stopPlaces.forEach(stopPlace => {
                 actionAffects.push({
@@ -300,9 +300,9 @@ export default class PtSituationElement {
     }
 
     private static computeLineNetwork(lineNetworkNode: Node): LineNetwork | null {
-        const operatorRef = XPathHelpers.queryText('siri:AffectedOperator/siri:OperatorRef', lineNetworkNode);
-        const lineRef = XPathHelpers.queryText('siri:LineRef', lineNetworkNode);
-        const publishedLineName = XPathHelpers.queryText('siri:PublishedLineName', lineNetworkNode);
+        const operatorRef = XPathHelpers.queryText('AffectedOperator/OperatorRef', lineNetworkNode);
+        const lineRef = XPathHelpers.queryText('LineRef', lineNetworkNode);
+        const publishedLineName = XPathHelpers.queryText('PublishedLineName', lineNetworkNode);
 
         if ((operatorRef === null) || (lineRef === null) || (publishedLineName === null)) {
             console.log('ERROR: LineNetwork cant init');
@@ -310,9 +310,9 @@ export default class PtSituationElement {
             return null;
         }
 
-        const directionRef = XPathHelpers.queryText('siri:Direction/siri:DirectionRef', lineNetworkNode);
+        const directionRef = XPathHelpers.queryText('Direction/DirectionRef', lineNetworkNode);
 
-        const stopPlaceNodes = XPathHelpers.queryNodes('siri:StopPlaces/siri:AffectedStopPlace', lineNetworkNode);
+        const stopPlaceNodes = XPathHelpers.queryNodes('StopPlaces/AffectedStopPlace', lineNetworkNode);
         const stopPlaces = PtSituationElement.computeAffectedStopPlaces(stopPlaceNodes);
 
         const lineNetwork: LineNetwork = {
@@ -332,8 +332,8 @@ export default class PtSituationElement {
         const stopPlaces: StopPlace[] = []
 
         stopPlaceNodes.forEach(stopPlaceNode => {
-            const stopPlaceRef = XPathHelpers.queryText('siri:StopPlaceRef', stopPlaceNode);
-            const placeName = XPathHelpers.queryText('siri:PlaceName', stopPlaceNode);
+            const stopPlaceRef = XPathHelpers.queryText('StopPlaceRef', stopPlaceNode);
+            const placeName = XPathHelpers.queryText('PlaceName', stopPlaceNode);
 
             if ((stopPlaceRef === null) || (placeName === null)) {
                 console.log('ERROR: StopPlace cant init');
@@ -356,7 +356,7 @@ export default class PtSituationElement {
 
         const affectedVehicleJourneyNodes = XPathHelpers.queryNodes('siri:PublishAtScope/siri:Affects/siri:VehicleJourneys/siri:AffectedVehicleJourney', publishingActionNode);
         affectedVehicleJourneyNodes.forEach((vehicleJourneyNode, idx) => {
-            const framedVehicleJourneyRefNode = XPathHelpers.queryNode('siri:FramedVehicleJourneyRef', vehicleJourneyNode);
+            const framedVehicleJourneyRefNode = XPathHelpers.queryNode('FramedVehicleJourneyRef', vehicleJourneyNode);
             if (framedVehicleJourneyRefNode === null) {
                 console.error('computeAffectedJourneys - NULL FramedVehicleJourneyRef');
                 console.log(situationNumber);
@@ -364,8 +364,8 @@ export default class PtSituationElement {
                 return;
             }
 
-            const dataFrameRef = XPathHelpers.queryText('siri:DataFrameRef', framedVehicleJourneyRefNode);
-            const datedVehicleJourneyRef = XPathHelpers.queryText('siri:DatedVehicleJourneyRef', framedVehicleJourneyRefNode);
+            const dataFrameRef = XPathHelpers.queryText('DataFrameRef', framedVehicleJourneyRefNode);
+            const datedVehicleJourneyRef = XPathHelpers.queryText('DatedVehicleJourneyRef', framedVehicleJourneyRefNode);
             if (dataFrameRef === null || datedVehicleJourneyRef === null) {
                 console.error('computeAffectedJourneys - NULL FramedVehicleJourneyRef members');
                 console.log(situationNumber);
@@ -378,7 +378,7 @@ export default class PtSituationElement {
                 datedVehicleJourneyRef: datedVehicleJourneyRef,
             }
             
-            const operatorRef = XPathHelpers.queryText('siri:Operator/siri:OperatorRef', vehicleJourneyNode);
+            const operatorRef = XPathHelpers.queryText('Operator/OperatorRef', vehicleJourneyNode);
             if (operatorRef === null) {
                 console.error('computeAffectedJourneys - NULL operatorRef');
                 console.log(situationNumber);
@@ -387,27 +387,27 @@ export default class PtSituationElement {
             }
 
             let origin: AffectedStopPlace | null = null;
-            const orginRef = XPathHelpers.queryText('siri:Origins/siri:StopPlaceRef', vehicleJourneyNode);
+            const orginRef = XPathHelpers.queryText('Origins/StopPlaceRef', vehicleJourneyNode);
             if (orginRef !== null) {
                 origin = {
                     stopPlaceRef: orginRef,
-                    placeName: XPathHelpers.queryText('siri:Origins/siri:PlaceName', vehicleJourneyNode)
+                    placeName: XPathHelpers.queryText('Origins/PlaceName', vehicleJourneyNode)
                 }
             }
 
             let destination: AffectedStopPlace | null = null;
-            const destinationRef = XPathHelpers.queryText('siri:Destinations/siri:StopPlaceRef', vehicleJourneyNode);
+            const destinationRef = XPathHelpers.queryText('Destinations/StopPlaceRef', vehicleJourneyNode);
             if (destinationRef !== null) {
                 destination = {
                     stopPlaceRef: destinationRef,
-                    placeName: XPathHelpers.queryText('siri:Destinations/siri:PlaceName', vehicleJourneyNode)
+                    placeName: XPathHelpers.queryText('Destinations/PlaceName', vehicleJourneyNode)
                 }
             }
             
-            const stopCallNodes = XPathHelpers.queryNodes('siri:Calls/siri:Call', vehicleJourneyNode);
+            const stopCallNodes = XPathHelpers.queryNodes('Calls/Call', vehicleJourneyNode);
             const callStopsRef: string[] = [];
             stopCallNodes.forEach(stopCallNode => {
-                const stopPlaceRef = XPathHelpers.queryText('siri:StopPlaceRef', stopCallNode);
+                const stopPlaceRef = XPathHelpers.queryText('StopPlaceRef', stopCallNode);
                 if (stopPlaceRef === null) {
                     return
                 }
@@ -415,8 +415,8 @@ export default class PtSituationElement {
                 callStopsRef.push(stopPlaceRef);
             });
 
-            const lineRef = XPathHelpers.queryText('siri:LineRef', vehicleJourneyNode);
-            const publishedLineName = XPathHelpers.queryText('siri:PublishedLineName', vehicleJourneyNode);
+            const lineRef = XPathHelpers.queryText('LineRef', vehicleJourneyNode);
+            const publishedLineName = XPathHelpers.queryText('PublishedLineName', vehicleJourneyNode);
 
             const affectedVehicleJourney: AffectedVehicleJourney = {
                 framedVehicleJourneyRef: framedVehicleJourneyRef,
@@ -437,7 +437,7 @@ export default class PtSituationElement {
     }
 
     private static computeTextualContent(textualContentNode: Node): TextualContent | null {
-        const summaryNode = XPathHelpers.queryNode('siri:SummaryContent', textualContentNode);
+        const summaryNode = XPathHelpers.queryNode('SummaryContent', textualContentNode);
         if (summaryNode === null) {
             console.log('No SummaryText found');
             console.log(textualContentNode);
@@ -445,7 +445,7 @@ export default class PtSituationElement {
         }
 
         const mapTextData: Record<string, TextualPropertyContent[]> = {};
-        const childNodes = XPathHelpers.queryNodes('siri:*', textualContentNode);
+        const childNodes = XPathHelpers.queryNodes('*', textualContentNode);
         childNodes.forEach(childNode => {
             const childEl = childNode as Element;
             const textKey = childEl.tagName.replace('Content', '');
@@ -476,7 +476,7 @@ export default class PtSituationElement {
     private static computeTextualPropertyContent(textualPropertyContentNode: Node): TextualPropertyContent {
         const textPropertyData: TextualPropertyContent = {} as TextualPropertyContent;
 
-        const textLangNodes = XPathHelpers.queryNodes('siri:*', textualPropertyContentNode);
+        const textLangNodes = XPathHelpers.queryNodes('*', textualPropertyContentNode);
             textLangNodes.forEach(textLangNode => {
                 const langKey: LangEnum | null = (() => {
                     let langS = (textLangNode as Element).getAttribute('xml:lang');

--- a/apps/siri-sx-demo-client/ts/models/pt_situation_source.ts
+++ b/apps/siri-sx-demo-client/ts/models/pt_situation_source.ts
@@ -14,14 +14,14 @@ export default class PtSituationSource {
     }
 
     public static initFromSituationNode(node: Node): PtSituationSource | null {
-        const countryRef = XPathHelpers.queryText('siri:Source/siri:CountryRef', node)
-        
-        if (!(countryRef && sourceType)) {
         const sourceType = XPathHelpers.queryText('Source/SourceType', node);
+        if (!sourceType) {
             console.log('ERROR - cant PtSituationSource.initFromSituationNode')
             console.log(node);
             return null;
         }
+
+        const countryRef = XPathHelpers.queryText('Source/CountryRef', node) ?? 'n/a CountryRef';
 
         const situationSource = new PtSituationSource(countryRef, sourceType);
 

--- a/apps/siri-sx-demo-client/ts/models/pt_situation_source.ts
+++ b/apps/siri-sx-demo-client/ts/models/pt_situation_source.ts
@@ -15,9 +15,9 @@ export default class PtSituationSource {
 
     public static initFromSituationNode(node: Node): PtSituationSource | null {
         const countryRef = XPathHelpers.queryText('siri:Source/siri:CountryRef', node)
-        const sourceType = XPathHelpers.queryText('siri:Source/siri:SourceType', node)
         
         if (!(countryRef && sourceType)) {
+        const sourceType = XPathHelpers.queryText('Source/SourceType', node);
             console.log('ERROR - cant PtSituationSource.initFromSituationNode')
             console.log(node);
             return null;
@@ -25,8 +25,8 @@ export default class PtSituationSource {
 
         const situationSource = new PtSituationSource(countryRef, sourceType);
 
-        situationSource.name = XPathHelpers.queryText('siri:Source/siri:Name', node)
-        situationSource.externalCode = XPathHelpers.queryText('siri:Source/siri:ExternalCode', node)
+        situationSource.name = XPathHelpers.queryText('Source/Name', node)
+        situationSource.externalCode = XPathHelpers.queryText('Source/ExternalCode', node)
 
         return situationSource
     }


### PR DESCRIPTION
- check if the feed can be pre-filtered to avoid memory issues
- dont use DOMParser against whole feed, use it for each PtSituationElement node
- check `<AffectedVehicleJourney>` nodes count and discard them when too many (more than 100)